### PR TITLE
Updating logic to consider occurrence_watermark when handling resolve events

### DIFF
--- a/lib/sensu/extensions/occurrences.rb
+++ b/lib/sensu/extensions/occurrences.rb
@@ -22,9 +22,8 @@ module Sensu
       def event_filtered?(event)
         check = event[:check]
         occurrences = check[:occurrences] || 1
-        watermark = event[:occurrences_watermark] || 1
         refresh = check[:refresh] || 1800
-        if event[:action] == :resolve && watermark >= occurrences
+        if event[:action] == :resolve && event[:occurrences_watermark] >= occurrences
           return ["enough occurrences", 1]
         elsif occurrences.is_a?(Integer) && refresh.is_a?(Integer)
           if event[:occurrences] < occurrences

--- a/lib/sensu/extensions/occurrences.rb
+++ b/lib/sensu/extensions/occurrences.rb
@@ -22,8 +22,11 @@ module Sensu
       def event_filtered?(event)
         check = event[:check]
         occurrences = check[:occurrences] || 1
+        watermark = event[:occurrences_watermark] || 1
         refresh = check[:refresh] || 1800
-        if occurrences.is_a?(Integer) && refresh.is_a?(Integer)
+        if event[:action] == :resolve && watermark >= occurrences
+          return ["enough occurrences", 1]
+        elsif occurrences.is_a?(Integer) && refresh.is_a?(Integer)
           if event[:occurrences] < occurrences
             return ["not enough occurrences", 0]
           end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -74,6 +74,7 @@ module Helpers
       :last_ok => one_second_ago,
       :last_state_change => one_second_ago,
       :occurrences => 1,
+      :occurrences_watermark => 1,
       :action => :create
     }
   end


### PR DESCRIPTION
Sensu 0.26 adds the `occurrences_watermark` event attribute which tracks the
"high water mark" for number of occurrences at the current severity.

This logic asserts that any resolve event should be handled if its
`occurrences_watermark` value is equal to or greater than the configured
check occurrences.